### PR TITLE
Fix gallery pagination

### DIFF
--- a/lib/philomena_web/templates/gallery/index.html.slime
+++ b/lib/philomena_web/templates/gallery/index.html.slime
@@ -1,6 +1,7 @@
 elixir:
   route = fn p -> Routes.gallery_path(@conn, :index, p) end
-  pagination = render PhilomenaWeb.PaginationView, "_pagination.html", page: @galleries, route: route, params: [gallery: @conn.params["gallery"]]
+  params = if @conn.params["gallery"] do [gallery: @conn.params["gallery"]] else nil end
+  pagination = render PhilomenaWeb.PaginationView, "_pagination.html", page: @galleries, route: route, params: params
 
 .column-layout
   .column-layout__left


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This change fixes pagination on the gallery index by not appending an empty `&gallery=` query parameter unless the search form on the left is used.

### Tests performed

**Environment:** Windows 10 using Firefox 78.0.2 with the application running in Docker

#### Without additional filtering

*Prerequsite:* Have at least 26 galleries in the system

1. <ins>**Click galleries navigation item**</ins>
    **Before changes:** Gallery index loads with pagination links to go to page 2, next and last ✔
    **After changes:**  Gallery index loads with pagination links to go to page 2, next and last ✔

2. <ins>**Hover over pagination link for page 2**</ins>
    **Before changes:** Browser displays the URL `http://localhost:8080/galleries?page=2&gallery=` in the bottom left corner ❌
    **After changes:**  Browser displays the URL `http://localhost:8080/galleries?page=2` in the bottom left corner ✔

3. <ins>**Click to go to the displayed URL**</ins>
    **Before changes:** [Application crashes](https://user-images.githubusercontent.com/3200580/88705393-c222da00-d10f-11ea-84d6-90a77561a48d.png) ❌
    **After changes:**  Browser displays the second page of results. URL: `http://localhost:8080/galleries?page=2`  ✔

#### With additional filtering

*Prerequsite:* Have at least 26 galleries in the system whose title contains "a", each of them created by the Administrator user

1. <ins>**Click galleries navigation item**</ins>
    **Before changes:** Gallery index loads with pagination links to go to page 2, next and last ✔
    **After changes:**  Gallery index loads with pagination links to go to page 2, next and last ✔

2. <ins>**Enter "a" in the "Title" text input on the left side of the gallery index and press Search**</ins>
    **Before changes:** Gallery index loads with only results that contain "a" in the title and pagination links to go to page 2, next and last. URL: ✔

    > `http://localhost:8080/galleries?gallery%5Btitle%5D=a&gallery%5Bdescription%5D=&gallery%5Bcreator%5D=&gallery%5Binclude_image%5D=&gallery%5Bsf%5D=created_at&gallery%5Bsd%5D=desc`

    **After changes:**  Gallery index loads with only results that contain "a" in the title and pagination links to go to page 2, next and last. URL: ✔

    > `http://localhost:8080/galleries?gallery%5Btitle%5D=a&gallery%5Bdescription%5D=&gallery%5Bcreator%5D=&gallery%5Binclude_image%5D=&gallery%5Bsf%5D=created_at&gallery%5Bsd%5D=desc`

3. <ins>**Hover over pagination link for page 2**</ins>
    **Before changes:** Browser displays the URL below in the bottom left corner ✔

    > `http://localhost:8080/galleries?page=2&gallery[creator]=&gallery[description]=&gallery[include_image]=&gallery[sd]=desc&gallery[sf]=created_at&gallery[title]=a`

    **After changes:**  Browser displays the URL below in the bottom left corner ✔

    > `http://localhost:8080/galleries?page=2&gallery[creator]=&gallery[description]=&gallery[include_image]=&gallery[sd]=desc&gallery[sf]=created_at&gallery[title]=a`

4. <ins>**Click to go to the displayed URL**</ins>
    **Before changes:** Browser displays the second page of results. URL: ✔

   > `http://localhost:8080/galleries?page=2&gallery[creator]=&gallery[description]=&gallery[include_image]=&gallery[sd]=desc&gallery[sf]=created_at&gallery[title]=a`

    **After changes:**  Browser displays the second page of results. URL: ✔

   > `http://localhost:8080/galleries?page=2&gallery[creator]=&gallery[description]=&gallery[include_image]=&gallery[sd]=desc&gallery[sf]=created_at&gallery[title]=a`

5. <ins>**Enter "Administrator" into the "Creator" field and press Search**</ins>
    **Before changes:** Browser displays the first page of results matching the criteria. URL: ✔

   > `http://localhost:8080/galleries?gallery%5Btitle%5D=a&gallery%5Bdescription%5D=&gallery%5Bcreator%5D=Administrator&gallery%5Binclude_image%5D=&gallery%5Bsf%5D=created_at&gallery%5Bsd%5D=desc`

    **After changes:**  Browser displays the first page of results matching the criteria. URL: ✔

   > `http://localhost:8080/galleries?gallery%5Btitle%5D=a&gallery%5Bdescription%5D=&gallery%5Bcreator%5D=Administrator&gallery%5Binclude_image%5D=&gallery%5Bsf%5D=created_at&gallery%5Bsd%5D=desc`

6. <ins>**Click navigation link to go to page 2**</ins>
    **Before changes:** Browser displays the second page of results matching the criteria. URL: ✔

    > `http://localhost:8080/galleries?page=2&gallery[creator]=Administrator&gallery[description]=&gallery[include_image]=&gallery[sd]=desc&gallery[sf]=created_at&gallery[title]=a`

    **After changes:**  Browser displays the second page of results matching the criteria. URL: ✔

    > `http://localhost:8080/galleries?page=2&gallery[creator]=Administrator&gallery[description]=&gallery[include_image]=&gallery[sd]=desc&gallery[sf]=created_at&gallery[title]=a`