### PR TITLE
Display nicer error message if username is taken

### DIFF
--- a/lib/philomena/users/user.ex
+++ b/lib/philomena/users/user.ex
@@ -153,6 +153,7 @@ defmodule Philomena.Users.User do
     |> pow_changeset(attrs)
     |> pow_extension_changeset(attrs)
     |> cast(attrs, [])
+    |> unsafe_validate_unique([:name], Repo)
     |> validate_required([])
     |> unique_constraints()
   end


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This will give users a clear error message in case they try to register with a username that already exists on the site.