### PR TITLE
add post creation via the API

### DIFF
--- a/lib/philomena_web/controllers/api/json/forum/topic/post_controller.ex
+++ b/lib/philomena_web/controllers/api/json/forum/topic/post_controller.ex
@@ -1,9 +1,16 @@
 defmodule PhilomenaWeb.Api.Json.Forum.Topic.PostController do
   use PhilomenaWeb, :controller
 
+  alias Philomena.Forums.Forum
   alias Philomena.Posts.Post
+  alias Philomena.Posts
+  alias Philomena.Topics.Topic
   alias Philomena.Repo
+  alias Philomena.UserStatistics
   import Ecto.Query
+
+  plug PhilomenaWeb.ApiRequireAuthorizationPlug when action in [:create]
+  plug PhilomenaWeb.UserAttributionPlug when action in [:create]
 
   def index(conn, %{"forum_id" => forum_id, "topic_id" => topic_id}) do
     page = conn.assigns.pagination.page_number
@@ -44,6 +51,53 @@ defmodule PhilomenaWeb.Api.Json.Forum.Topic.PostController do
 
       true ->
         render(conn, "show.json", post: post)
+    end
+  end
+
+  def create(conn, %{"forum_id" => forum_id, "topic_id" => topic_id, "post" => post_params}) do
+    attributes = conn.assigns.attributes
+
+    topic =
+      Topic
+      |> join(:inner, [t], _ in assoc(t, :forum))
+      |> where(slug: ^topic_id)
+      |> where(hidden_from_users: false)
+      |> where([_t, f], f.access_level == "normal" and f.short_name == ^forum_id)
+      |> order_by(desc: :sticky, desc: :last_replied_to_at)
+      |> preload([:user])
+      |> Repo.one()
+
+    forum =
+      Forum
+      |> where(short_name: ^forum_id)
+      |> where(access_level: "normal")
+      |> Repo.one()
+
+    case Posts.create_post(topic, attributes, post_params) do
+      {:ok, %{post: post}} ->
+        Posts.notify_post(post)
+        Posts.reindex_post(post)
+        UserStatistics.inc_stat(conn.assigns.current_user, :forum_posts)
+
+        if forum.access_level == "normal" do
+          PhilomenaWeb.Endpoint.broadcast!(
+            "firehose",
+            "post:create",
+            PhilomenaWeb.Api.Json.Forum.Topic.PostView.render("firehose.json", %{
+                  post: post,
+                  topic: topic,
+                  forum: forum
+            })
+          )
+        end
+
+        render(conn, "show.json", post: post)
+
+      {:error, :post, changeset, _} ->
+        conn
+        |> put_status(:bad_request)
+        |> put_view(PhilomenaWeb.Api.Json.Forum.Topic.PostView)
+        |> render("error.json", changeset: changeset)
     end
   end
 end

--- a/lib/philomena_web/router.ex
+++ b/lib/philomena_web/router.ex
@@ -140,7 +140,7 @@ defmodule PhilomenaWeb.Router do
 
     resources "/forums", ForumController, only: [:show, :index] do
       resources "/topics", Forum.TopicController, only: [:show, :index] do
-        resources "/posts", Forum.Topic.PostController, only: [:show, :index]
+        resources "/posts", Forum.Topic.PostController, only: [:show, :index, :create]
       end
     end
   end

--- a/lib/philomena_web/views/api/json/forum/topic/post_view.ex
+++ b/lib/philomena_web/views/api/json/forum/topic/post_view.ex
@@ -61,4 +61,10 @@ defmodule PhilomenaWeb.Api.Json.Forum.Topic.PostView do
       edit_reason: post.edit_reason
     }
   end
+
+  def render("error.json", %{changeset: changeset}) do
+    %{
+      errors: Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+    }
+  end
 end


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This offers the following routes (given as a RFC 6570 URL template):

| route | why | needs |
|:----- |:----- |:----- |
| `POST /api/v1/json/forums/{forum_slug}/topics/{topic_slug}/posts` | Creates a new post in a forum by slug's thread by slug | `?key={your_api_key}` and `{"post": {"body": "textile markup", "anonymous": true/false}}` as the body |

This also announces new forum posts to the Firehose API like they would be if they were made using the web UI.