### PR TITLE
Fix being able to vote on polls past their end date

### DIFF
--- a/lib/philomena/poll_votes.ex
+++ b/lib/philomena/poll_votes.ex
@@ -7,6 +7,7 @@ defmodule Philomena.PollVotes do
   alias Ecto.Multi
   alias Philomena.Repo
 
+  alias Philomena.Polls
   alias Philomena.Polls.Poll
   alias Philomena.PollVotes.PollVote
   alias Philomena.PollOptions.PollOption
@@ -44,6 +45,13 @@ defmodule Philomena.PollVotes do
     poll_votes = filter_options(user, poll, now, attrs)
 
     Multi.new()
+    |> Multi.run(:ended, fn _repo, _changes ->
+      # Bail if poll is no longer active
+      case Polls.active?(poll) do
+        false -> {:error, []}
+        _true -> {:ok, []}
+      end
+    end)
     |> Multi.run(:existing_votes, fn _repo, _changes ->
       # Don't proceed if any votes exist
       case voted?(poll, user) do

--- a/lib/philomena/polls.ex
+++ b/lib/philomena/polls.ex
@@ -101,4 +101,12 @@ defmodule Philomena.Polls do
   def change_poll(%Poll{} = poll) do
     Poll.changeset(poll, %{})
   end
+
+  def active?(%{id: poll_id}) do
+    now = DateTime.utc_now()
+
+    Poll
+    |> where([p], p.id == ^poll_id and p.active_until > ^now)
+    |> Repo.exists?()
+  end
 end

--- a/lib/philomena/polls/poll.ex
+++ b/lib/philomena/polls/poll.ex
@@ -5,7 +5,9 @@ defmodule Philomena.Polls.Poll do
   alias Philomena.Topics.Topic
   alias Philomena.Users.User
   alias Philomena.PollOptions.PollOption
+  alias Philomena.Polls.Poll
   alias Philomena.Schema.Time
+  import Ecto.Query
 
   schema "polls" do
     belongs_to :topic, Topic

--- a/lib/philomena_web/controllers/topic_controller.ex
+++ b/lib/philomena_web/controllers/topic_controller.ex
@@ -3,7 +3,7 @@ defmodule PhilomenaWeb.TopicController do
 
   alias PhilomenaWeb.NotificationCountPlug
   alias Philomena.{Forums.Forum, Topics.Topic, Posts.Post, Polls.Poll, PollOptions.PollOption}
-  alias Philomena.{Forums, Topics, Posts}
+  alias Philomena.{Forums, Topics, Polls, Posts}
   alias Philomena.PollVotes
   alias PhilomenaWeb.TextileRenderer
   alias Philomena.Repo
@@ -72,6 +72,8 @@ defmodule PhilomenaWeb.TopicController do
 
     voted = PollVotes.voted?(topic.poll, conn.assigns.current_user)
 
+    poll_active = Polls.active?(topic.poll)
+
     changeset =
       %Post{}
       |> Posts.change_post()
@@ -86,7 +88,8 @@ defmodule PhilomenaWeb.TopicController do
       changeset: changeset,
       topic_changeset: topic_changeset,
       watching: watching,
-      voted: voted
+      voted: voted,
+      poll_active: poll_active
     )
   end
 

--- a/lib/philomena_web/templates/topic/poll/_display.html.slime
+++ b/lib/philomena_web/templates/topic/poll/_display.html.slime
@@ -16,7 +16,7 @@
           strong
             = @poll.deletion_reason || "Unknown (likely deleted in error). Please contact a moderator."
 
-    - not @voted and not is_nil(@conn.assigns.current_user) ->
+    - @poll_active and not @voted and not is_nil(@conn.assigns.current_user) ->
       .poll
         .poll-area
           = render PhilomenaWeb.Topic.PollView, "_vote_form.html", assigns


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of Derpibooru and/or the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x] I understand all of the above

---

This change will disallow voting on polls past their end date and display only the results view once the poll has ended.
