### PR TITLE
Add link to getting started page

### DIFF
--- a/config/footer.json
+++ b/config/footer.json
@@ -35,6 +35,11 @@
   ],
   "Help & Information": [
     {
+      "title": "Getting Started",
+      "url": "/pages/start",
+      "bold": true
+    },
+    {
       "title": "Changelog",
       "url": "https://github.com/furbooru/philomena/commits/master",
       "bold": true


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [x ] I understand all of the above

---

Add a link to the "Getting Started" page under "Help & Information" in the site's footer.
