### PR TITLE
In upload, in url field, fetch when 'enter' key

### DIFF
--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -108,6 +108,13 @@ function setupImageUpload() {
     }).catch(showError);
   });
 
+  // Fetch on "enter" in url field
+  remoteUrl.addEventListener("keydown", function(event) {
+    if (event.keyCode === 13) { // Hit enter
+      fetchButton.click();
+    }
+  });
+
   // Enable/disable the fetch button based on content in the image scraper. Fetching with no URL makes no sense.
   remoteUrl.addEventListener('input', () => {
     if (remoteUrl.value.length > 0) {


### PR DESCRIPTION
### Before you begin

* I understand my contributions may be rejected for any reason
* I understand my contributions are for the benefit of the Philomena software
* I understand my contributions are licensed under the GNU AGPLv3

- [X] I understand all of the above

---

It's inconvenient when you have to take your hands off the keyboard when uploading multiple images.  When you're in the url field, hitting enter doesn't fetch the image, but it seems like it should, and I've wished it did.  I've added a bit of code that causes the Fetch button to be clicked when enter is pressed in the url field.  I don't believe it alters the page's behavior in any other way.